### PR TITLE
Use correct case for JSONModel header import

### DIFF
--- a/KeePassHTTPKit/KPHResponse.h
+++ b/KeePassHTTPKit/KPHResponse.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "JSonModel.h"
+#import "JSONModel.h"
 
 @protocol KPHResponseStringField
 @end


### PR DESCRIPTION
I'm unable to build MacPassHTTP on my case-sensitive OS X file system. This pull request should fix the issue. Executing `xcodebuild` gives the following error:
```
While building module 'KeePassHTTPKit' imported from /Users/slovdahl/dev/MacPassHTTP/MacPassHTTP/MPHServerDelegate.h:10:
In file included from <module-includes>:1:
In file included from /Users/slovdahl/dev/MacPassHTTP/Carthage/Build/Mac/KeePassHTTPKit.framework/Headers/KeePassHTTPKit.h:20:
/Users/slovdahl/dev/MacPassHTTP/Carthage/Build/Mac/KeePassHTTPKit.framework/Headers/KPHResponse.h:10:9: fatal error:
      'JSonModel.h' file not found
#import "JSonModel.h"
        ^
1 error generated.
```

Would you be able to merge this pull request and update KeePassHTTP to depend on a version with this fix included?